### PR TITLE
New iava support and numerous other enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,55 +15,55 @@ If you don't have a GitHub account but do have a Red Hat Portal login, go here: 
 - [Find CVEs](#find-cves)
   - [Empty search: list CVEs by public-date](#empty-search-list-cves-by-public-date)
   - [Find CVEs by attributes](#find-cves-by-attributes)
-  - [Find CVEs by IAVA](#find-cves-by-iava)
+- [Working with IAVAs](#working-with-iavas)
 - [Advanced: find unresolved CVEs for a specific package in a specific product](#advanced-find-unresolved-cves-for-a-specific-package-in-a-specific-product)
 - [Full help page](#full-help-page)
 - [Working with backend rhsda library](#working-with-backend-rhsda-library)
 
 ## Simple CVE retrieval
 
-Specify as many CVEs on cmdline as needed; certain details are printed to stderr -- e.g., in the following, the first 4 lines of output were sent to stderr
+Specify as many CVEs on cmdline as needed; certain details are printed to stderr -- e.g., in the following, the first 3 lines of output were sent to stderr
 
 ```
 $ rhsecapi CVE-2013-4113 CVE-2014-3669 CVE-2004-0230 CVE-2015-4642
+[NOTICE ] rhsda: Found 4 CVEs on cmdline
 [NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 3 of 4
-[NOTICE ] rhsda: Invalid CVE queries: 1 of 4
 
 CVE-2013-4113
-  SEVERITY: Critical Impact
-  DATE:     2013-07-11
-  BUGZILLA: 983689
-  FIXED_RELEASES:
-   Red Hat Enterprise Linux 5 [php-5.1.6-40.el5_9]: RHSA-2013:1049
-   Red Hat Enterprise Linux 5 [php53-5.3.3-13.el5_9.1]: RHSA-2013:1050
-   Red Hat Enterprise Linux 6 [php-5.3.3-23.el6_4]: RHSA-2013:1049
-   Red Hat Enterprise Linux Extended Lifecycle Support 3 [php-4.3.2-56.ent]: RHSA-2013:1063
-   Red Hat Enterprise Linux Extended Lifecycle Support 4 [php-4.3.9-3.37.el4]: RHSA-2013:1063
-   Red Hat Enterprise Linux EUS (v. 5.6 server) [php-5.1.6-27.el5_6.5]: RHSA-2013:1061
-   Red Hat Enterprise Linux EUS (v. 5.6 server) [php53-5.3.3-1.el5_6.3]: RHSA-2013:1062
-   Red Hat Enterprise Linux Extended Update Support 6.2 [php-5.3.3-3.el6_2.10]: RHSA-2013:1061
-   Red Hat Enterprise Linux Extended Update Support 6.3 [php-5.3.3-14.el6_3.1]: RHSA-2013:1061
-   Red Hat Enterprise Linux Long Life (v. 5.3 server) [php-5.1.6-23.4.el5_3]: RHSA-2013:1061
-  FIX_STATES:
+  SEVERITY : Critical Impact
+  DATE     : 2013-07-11
+  BUGZILLA : 983689
+  FIXED_RELEASES :
+   Red Hat Enterprise Linux 5: [php-5.1.6-40.el5_9] via RHSA-2013:1049 (2013-07-12)
+   Red Hat Enterprise Linux 5: [php53-5.3.3-13.el5_9.1] via RHSA-2013:1050 (2013-07-12)
+   Red Hat Enterprise Linux 6: [php-5.3.3-23.el6_4] via RHSA-2013:1049 (2013-07-12)
+   Red Hat Enterprise Linux Extended Lifecycle Support 3: [php-4.3.2-56.ent] via RHSA-2013:1063 (2013-07-15)
+   Red Hat Enterprise Linux Extended Lifecycle Support 4: [php-4.3.9-3.37.el4] via RHSA-2013:1063 (2013-07-15)
+   Red Hat Enterprise Linux EUS (v. 5.6 server): [php-5.1.6-27.el5_6.5] via RHSA-2013:1061 (2013-07-15)
+   Red Hat Enterprise Linux EUS (v. 5.6 server): [php53-5.3.3-1.el5_6.3] via RHSA-2013:1062 (2013-07-15)
+   Red Hat Enterprise Linux Extended Update Support 6.2: [php-5.3.3-3.el6_2.10] via RHSA-2013:1061 (2013-07-15)
+   Red Hat Enterprise Linux Extended Update Support 6.3: [php-5.3.3-14.el6_3.1] via RHSA-2013:1061 (2013-07-15)
+   Red Hat Enterprise Linux Long Life (v. 5.3 server): [php-5.1.6-23.4.el5_3] via RHSA-2013:1061 (2013-07-15)
+  FIX_STATES :
    Not affected: Red Hat Enterprise Linux 7 [php]
 
 CVE-2014-3669
-  SEVERITY: Moderate Impact
-  DATE:     2014-09-18
-  BUGZILLA: 1154500
-  FIXED_RELEASES:
-   Red Hat Enterprise Linux 5 [php53-5.3.3-26.el5_11]: RHSA-2014:1768
-   Red Hat Enterprise Linux 5 [php-5.1.6-45.el5_11]: RHSA-2014:1824
-   Red Hat Enterprise Linux 6 [php-5.3.3-40.el6_6]: RHSA-2014:1767
-   Red Hat Enterprise Linux 7 [php-5.4.16-23.el7_0.3]: RHSA-2014:1767
-   Red Hat Enterprise Linux Extended Update Support 6.5 [php-5.3.3-27.el6_5.3]: RHSA-2015:0021
-   Red Hat Software Collections 1 for Red Hat Enterprise Linux Server (v. 6) [php54-php-5.4.16-22.el6]: RHSA-2014:1765
-   Red Hat Software Collections 1 for Red Hat Enterprise Linux Server (v. 6) [php55-php-5.5.6-13.el6]: RHSA-2014:1766
-   Red Hat Software Collections 1 for Red Hat Enterprise Linux Server (v. 7) [php54-php-5.4.16-22.el7]: RHSA-2014:1765
-   Red Hat Software Collections 1 for Red Hat Enterprise Linux Server (v. 7) [php55-php-5.5.6-13.el7]: RHSA-2014:1766
+  SEVERITY : Moderate Impact
+  DATE     : 2014-09-18
+  BUGZILLA : 1154500
+  FIXED_RELEASES :
+   Red Hat Enterprise Linux 5: [php53-5.3.3-26.el5_11] via RHSA-2014:1768 (2014-10-30)
+   Red Hat Enterprise Linux 5: [php-5.1.6-45.el5_11] via RHSA-2014:1824 (2014-11-06)
+   Red Hat Enterprise Linux 6: [php-5.3.3-40.el6_6] via RHSA-2014:1767 (2014-10-30)
+   Red Hat Enterprise Linux 7: [php-5.4.16-23.el7_0.3] via RHSA-2014:1767 (2014-10-30)
+   Red Hat Enterprise Linux Extended Update Support 6.5: [php-5.3.3-27.el6_5.3] via RHSA-2015:0021 (2015-01-08)
+   Red Hat Software Collections 1 for Red Hat Enterprise Linux Server (v. 6): [php54-php-5.4.16-22.el6] via RHSA-2014:1765 (2014-10-30)
+   Red Hat Software Collections 1 for Red Hat Enterprise Linux Server (v. 6): [php55-php-5.5.6-13.el6] via RHSA-2014:1766 (2014-10-30)
+   Red Hat Software Collections 1 for Red Hat Enterprise Linux Server (v. 7): [php54-php-5.4.16-22.el7] via RHSA-2014:1765 (2014-10-30)
+   Red Hat Software Collections 1 for Red Hat Enterprise Linux Server (v. 7): [php55-php-5.5.6-13.el7] via RHSA-2014:1766 (2014-10-30)
 
 CVE-2004-0230
-  BUGZILLA: No Bugzilla data
+  BUGZILLA : No Bugzilla data
    Too new or too old? See: https://bugzilla.redhat.com/show_bug.cgi?id=CVE_legacy
 
 CVE-2015-4642
@@ -75,26 +75,26 @@ A `--product` option allows spotlighting a particular product via a case-insenst
 
 ```
 $ rhsecapi CVE-2013-4113 CVE-2014-3669 CVE-2004-0230 CVE-2015-4642 --product eus
+[NOTICE ] rhsda: Found 4 CVEs on cmdline
 [NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 3 of 4
 [NOTICE ] rhsda: Results matching spotlight-product option: 2 of 4
-[NOTICE ] rhsda: Invalid CVE queries: 1 of 4
 
 CVE-2013-4113
-  SEVERITY: Critical Impact
-  DATE:     2013-07-11
-  BUGZILLA: 983689
-  FIXED_RELEASES matching 'eus':
-   Red Hat Enterprise Linux EUS (v. 5.6 server) [php-5.1.6-27.el5_6.5]: RHSA-2013:1061
-   Red Hat Enterprise Linux EUS (v. 5.6 server) [php53-5.3.3-1.el5_6.3]: RHSA-2013:1062
-   Red Hat Enterprise Linux Extended Update Support 6.2 [php-5.3.3-3.el6_2.10]: RHSA-2013:1061
-   Red Hat Enterprise Linux Extended Update Support 6.3 [php-5.3.3-14.el6_3.1]: RHSA-2013:1061
+  SEVERITY : Critical Impact
+  DATE     : 2013-07-11
+  BUGZILLA : 983689
+  FIXED_RELEASES matching 'eus' :
+   Red Hat Enterprise Linux EUS (v. 5.6 server): [php-5.1.6-27.el5_6.5] via RHSA-2013:1061 (2013-07-15)
+   Red Hat Enterprise Linux EUS (v. 5.6 server): [php53-5.3.3-1.el5_6.3] via RHSA-2013:1062 (2013-07-15)
+   Red Hat Enterprise Linux Extended Update Support 6.2: [php-5.3.3-3.el6_2.10] via RHSA-2013:1061 (2013-07-15)
+   Red Hat Enterprise Linux Extended Update Support 6.3: [php-5.3.3-14.el6_3.1] via RHSA-2013:1061 (2013-07-15)
 
 CVE-2014-3669
-  SEVERITY: Moderate Impact
-  DATE:     2014-09-18
-  BUGZILLA: 1154500
-  FIXED_RELEASES matching 'eus':
-   Red Hat Enterprise Linux Extended Update Support 6.5 [php-5.3.3-27.el6_5.3]: RHSA-2015:0021
+  SEVERITY : Moderate Impact
+  DATE     : 2014-09-18
+  BUGZILLA : 1154500
+  FIXED_RELEASES matching 'eus' :
+   Red Hat Enterprise Linux Extended Update Support 6.5: [php-5.3.3-27.el6_5.3] via RHSA-2015:0021 (2015-01-08)
 ```
 
 A `--urls` or `-u` option adds URLS
@@ -102,29 +102,29 @@ A `--urls` or `-u` option adds URLS
 ```
 $ rhsecapi CVE-2013-4113 CVE-2014-3669 CVE-2004-0230 CVE-2015-4642 --product eus --urls 2>/dev/null
 CVE-2013-4113 (https://access.redhat.com/security/cve/CVE-2013-4113)
-  SEVERITY: Critical Impact (https://access.redhat.com/security/updates/classification)
-  DATE:     2013-07-11
-  BUGZILLA: https://bugzilla.redhat.com/show_bug.cgi?id=983689
-  FIXED_RELEASES matching 'eus':
-   Red Hat Enterprise Linux EUS (v. 5.6 server) [php-5.1.6-27.el5_6.5]: https://access.redhat.com/errata/RHSA-2013:1061
-   Red Hat Enterprise Linux EUS (v. 5.6 server) [php53-5.3.3-1.el5_6.3]: https://access.redhat.com/errata/RHSA-2013:1062
-   Red Hat Enterprise Linux Extended Update Support 6.2 [php-5.3.3-3.el6_2.10]: https://access.redhat.com/errata/RHSA-2013:1061
-   Red Hat Enterprise Linux Extended Update Support 6.3 [php-5.3.3-14.el6_3.1]: https://access.redhat.com/errata/RHSA-2013:1061
+  SEVERITY : Critical Impact (https://access.redhat.com/security/updates/classification)
+  DATE     : 2013-07-11
+  BUGZILLA : https://bugzilla.redhat.com/show_bug.cgi?id=983689
+  FIXED_RELEASES matching 'eus' :
+   Red Hat Enterprise Linux EUS (v. 5.6 server): [php-5.1.6-27.el5_6.5] via https://access.redhat.com/errata/RHSA-2013:1061 (2013-07-15)
+   Red Hat Enterprise Linux EUS (v. 5.6 server): [php53-5.3.3-1.el5_6.3] via https://access.redhat.com/errata/RHSA-2013:1062 (2013-07-15)
+   Red Hat Enterprise Linux Extended Update Support 6.2: [php-5.3.3-3.el6_2.10] via https://access.redhat.com/errata/RHSA-2013:1061 (2013-07-15)
+   Red Hat Enterprise Linux Extended Update Support 6.3: [php-5.3.3-14.el6_3.1] via https://access.redhat.com/errata/RHSA-2013:1061 (2013-07-15)
 
 CVE-2014-3669 (https://access.redhat.com/security/cve/CVE-2014-3669)
-  SEVERITY: Moderate Impact (https://access.redhat.com/security/updates/classification)
-  DATE:     2014-09-18
-  BUGZILLA: https://bugzilla.redhat.com/show_bug.cgi?id=1154500
-  FIXED_RELEASES matching 'eus':
-   Red Hat Enterprise Linux Extended Update Support 6.5 [php-5.3.3-27.el6_5.3]: https://access.redhat.com/errata/RHSA-2015:0021
+  SEVERITY : Moderate Impact (https://access.redhat.com/security/updates/classification)
+  DATE     : 2014-09-18
+  BUGZILLA : https://bugzilla.redhat.com/show_bug.cgi?id=1154500
+  FIXED_RELEASES matching 'eus' :
+   Red Hat Enterprise Linux Extended Update Support 6.5: [php-5.3.3-27.el6_5.3] via https://access.redhat.com/errata/RHSA-2015:0021 (2015-01-08)
 ```
 
-CVEs can also be extracted from stdin with `--extract-stdin` (`-0`) which uses case-insensitive regular expressions; note that the following examples use `--count` for the sake of brevity
+CVEs can also be extracted from stdin with `-0`/`--stdin` which uses case-insensitive regular expressions. Regex is also used to extract CVEs from cmdline args, so any arbitrary block of text can be dropped in as args if it's quoted. (Note that the following examples use `--count` for the sake of brevity.)
 
 First example: pasting newline-separated CVEs with shell heredoc redirection
 
 ```
-$ rhsecapi --extract-stdin --count <<EOF
+$ rhsecapi --stdin --count <<EOF
 > CVE-2016-5630 
 > CVE-2016-5631 
 > CVE-2016-5632 
@@ -132,22 +132,22 @@ $ rhsecapi --extract-stdin --count <<EOF
 > CVE-2016-5634 
 > CVE-2016-5635 
 > EOF
-[NOTICE ] rhsda: Found 6 CVEs in stdin; 0 duplicates removed
+[NOTICE ] rhsda: Found 6 CVEs on stdin
 [WARNING] rhsda: Stdin redirection suppresses term-width auto-detection; setting WIDTH to 70
 [NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 6 of 6
 ```
 
-Second example: piping in file(s) with `cat|` or file redirection (`< somefile`)
+Second example: piping in file(s) with `cat|` or file redirection (`< somefile`) while at the same time pasting some comma-separate CVEs on the cmdline
 
 ```
-$ cat scan-results.csv | rhsecapi -0 -c
-[NOTICE ] rhsda: Found 150 CVEs in stdin; 698 duplicates removed
+$ cat scan-results.csv | rhsecapi --stdin "(CVE-2015-7501), (CVE-2015-5178, CVE-2015-5188, CVE-2015-5220) and (CVE-2013-4517, CVE-2013-6440, CVE-2014-0018)" --count 
+[NOTICE ] rhsda: Found 7 CVEs on cmdline
+[NOTICE ] rhsda: Found 150 CVEs on stdin; 698 duplicates removed
 [WARNING] rhsda: Stdin redirection suppresses term-width auto-detection; setting WIDTH to 70
-[NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 148 of 150
-[NOTICE ] rhsda: Invalid CVE queries: 2 of 150
+[NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 155 of 157
 ```
 
-The CVE retrieval process is multi-threaded; with CPUcount < 4, it defaults to 4 threads; with CPUcount > 4, it defaults to `CPUcount * 2` 
+The CVE retrieval process is multi-threaded; with CPUcount <= 2, it defaults to 4 threads; otherwise, it defaults to `CPUcount * 2` 
 
 ```
 $ grep processor /proc/cpuinfo | wc -l
@@ -157,7 +157,7 @@ $ rhsecapi --help | grep -A1 threads
   -t, --threads THREDS  Set number of concurrent worker threads to allow when
                         making CVE queries (default on this system: 8)
 
-$ time rhsecapi --q-empty --q-pagesize 48 --extract-search >/dev/null
+$ time rhsecapi --q-empty --q-pagesize 48 --extract-cves >/dev/null
 [NOTICE ] rhsda: 48 CVEs found with search query
 [NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 48 of 48
 
@@ -188,7 +188,7 @@ usage: rhsecapi [--q-before YYYY-MM-DD] [--q-after YYYY-MM-DD] [--q-bug BZID]
                 [--q-advisory RHSA] [--q-severity IMPACT] [--q-package PKG]
                 [--q-cwe CWEID] [--q-cvss SCORE] [--q-cvss3 SCORE] [--q-empty]
                 [--q-pagesize PAGESZ] [--q-pagenum PAGENUM] [--q-raw RAWQUERY]
-                [--q-iava IAVA] [-s] [-0] [-f FIELDS | -a | -m] [-p PRODUCT]
+                [-i YYYY-?-NNNN] [-x] [-0] [-f FIELDS | -a | -m] [-p PRODUCT]
                 [-j] [-u] [-w [WIDTH]] [-c] [-l {debug,info,notice,warning}]
                 [-t THREDS] [-P] [-E [DAYS]] [--dryrun] [-h] [--help]
                 [CVE-YYYY-NNNN [CVE-YYYY-NNNN ...]]
@@ -196,7 +196,7 @@ usage: rhsecapi [--q-before YYYY-MM-DD] [--q-after YYYY-MM-DD] [--q-bug BZID]
 Run rhsecapi --help for full help page
 
 VERSION:
-  rhsecapi v1.0.0_rc5 last mod 2016/11/22
+  rhsecapi v1.0.0_rc8 last mod 2016/12/01
   See <http://github.com/ryran/rhsecapi> to report bugs or RFEs
 ```
 
@@ -204,12 +204,12 @@ VERSION:
 
 ```
 $ rhsecapi --[TabTab]
---all-fields      --help            --product         --q-cvss3         --q-pagesize
---count           --json            --q-advisory      --q-cwe           --q-raw
---dryrun          --loglevel        --q-after         --q-empty         --q-severity
---extract-search  --most-fields     --q-before        --q-iava          --threads
---extract-stdin   --pastebin        --q-bug           --q-package       --urls
---fields          --pexpire         --q-cvss          --q-pagenum       --wrap
+--all-fields    --iava          --product       --q-cvss3       --q-raw
+--count         --json          --q-advisory    --q-cwe         --q-severity
+--dryrun        --loglevel      --q-after       --q-empty       --stdin
+--extract-cves  --most-fields   --q-before      --q-package     --threads
+--fields        --pastebin      --q-bug         --q-pagenum     --urls
+--help          --pexpire       --q-cvss        --q-pagesize    --wrap
 ```
 
 ## Field display
@@ -218,20 +218,21 @@ Add some fields to the defaults with `--fields +field[,field]...` and note that 
 
 ```
 $ rhsecapi CVE-2016-6302 --fields +CWE,cvss3 --loglevel info
+[NOTICE ] rhsda: Found 1 CVEs on cmdline
 [INFO   ] rhsda: Using 1 worker threads
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-6302.json' ...
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-6302.json
 [NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 1 of 1
 
 CVE-2016-6302
-  SEVERITY: Moderate Impact
-  DATE:     2016-08-23
-  CWE:      CWE-190->CWE-125
-  CVSS3:    5.9 (CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H)
-  BUGZILLA: 1369855
-  FIXED_RELEASES:
-   Red Hat Enterprise Linux 6 [openssl-1.0.1e-48.el6_8.3]: RHSA-2016:1940
-   Red Hat Enterprise Linux 7 [openssl-1:1.0.1e-51.el7_2.7]: RHSA-2016:1940
-  FIX_STATES:
+  SEVERITY : Moderate Impact
+  DATE     : 2016-08-23
+  CWE      : CWE-190->CWE-125
+  CVSS3    : 5.9 (CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H)
+  BUGZILLA : 1369855
+  FIXED_RELEASES :
+   Red Hat Enterprise Linux 6: [openssl-1.0.1e-48.el6_8.3] via RHSA-2016:1940 (2016-09-27)
+   Red Hat Enterprise Linux 7: [openssl-1:1.0.1e-51.el7_2.7] via RHSA-2016:1940 (2016-09-27)
+  FIX_STATES :
    Affected: Red Hat JBoss Core Services 1 [openssl]
    Affected: Red Hat JBoss EAP 6 [openssl]
    Will not fix: Red Hat JBoss EWS 1 [openssl]
@@ -248,20 +249,20 @@ Remove some fields from the list of all fields with `--fields ^field[,field]...`
 
 ```
 $ rhsecapi CVE-2016-6302 -f ^FIXED_reLEASES,fIx_sTaTes,DETAILS -l info
+[NOTICE ] rhsda: Found 1 CVEs on cmdline
 [INFO   ] rhsda: Using 1 worker threads
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-6302.json' ...
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-6302.json
 [NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 1 of 1
 
 CVE-2016-6302
-  SEVERITY: Moderate Impact
-  DATE:     2016-08-23
-  IAVA:     2016-A-0262
-  CWE:      CWE-190->CWE-125
-  CVSS:     4.3 (AV:N/AC:M/Au:N/C:N/I:N/A:P)
-  CVSS3:    5.9 (CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H)
-  BUGZILLA: 1369855
-  UPSTREAM_FIX:  openssl 1.0.1u, openssl 1.0.2i
-  REFERENCES:
+  SEVERITY : Moderate Impact
+  DATE     : 2016-08-23
+  CWE      : CWE-190->CWE-125
+  CVSS     : 4.3 (AV:N/AC:M/Au:N/C:N/I:N/A:P)
+  CVSS3    : 5.9 (CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H)
+  BUGZILLA : 1369855
+  UPSTREAM_FIX : openssl 1.0.1u, openssl 1.0.2i
+  REFERENCES :
    https://www.openssl.org/news/secadv/20160922.txt
 ```
 
@@ -278,238 +279,162 @@ $ rhsecapi CVE-2016-6302 --loglevel debug --all-fields 2>&1 | grep fields
 ```
 
 ## Find CVEs
-The `--q-xxx` options can be combined to craft a search, listing CVEs via a single API call; add `--extract-search` (`-s`) to perform individual CVE queries against each CVE returned by the search 
+The `--q-xxx` options can be combined to craft a search, listing CVEs via a single API call; add `--extract-cves` (`-x`) to perform individual CVE queries against each CVE returned by the search 
 
 ### Empty search: list CVEs by public-date
 
 ```
- $ rhsecapi --loglevel info --q-empty
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve.json' ...
+$ rhsecapi --loglevel info --q-empty
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve.json
 [NOTICE ] rhsda: 1000 CVEs found with search query
 
-CVE-2016-9401
-CVE-2016-9372
-CVE-2016-9066
-CVE-2016-9064
-CVE-2016-8635
-CVE-2016-9374
-... (output truncated for brevity of this README)
+CVE ID            PUB DATE    BUGZILLA  SEVERITY   CVSS2  CVSS3  RHSAS  PKGS
+CVE-2016-9685     2016-12-01  1396941   low        2.1    3.8     0      0  
+CVE-2016-9079     2016-12-01  1400376   important  6.8    7.3     0      0  
+CVE-2016-5402     2016-11-30  1357559   important  8.5    8.8     1      1  
+CVE-2016-8734     2016-11-29  1397403   moderate   3.5    4.4     0      0  
+...
+(output truncated for brevity of this README)
 ```
 
+Customize how many results to see and print; add URLs.
+
 ```
-$ rhsecapi -l info --q-empty --q-pagesize 4 --q-pagenum 3
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve.json?per_page=5&page=3' ...
+$ rhsecapi --loglevel info --q-empty --q-pagesize 4 --q-pagenum 3 --urls 
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve.json?per_page=4&page=3
 [NOTICE ] rhsda: 4 CVEs found with search query
 
-CVE-2016-5297
-CVE-2016-9376
-CVE-2016-5290
-CVE-2016-5291
+CVE ID                                                PUB DATE    BUGZILLA                                             SEVERITY   CVSS2  CVSS3  RHSAS  PKGS
+https://access.redhat.com/security/cve/CVE-2016-8653  2016-11-25  https://bugzilla.redhat.com/show_bug.cgi?id=1398524  moderate   5.0    5.3     0      0  
+https://access.redhat.com/security/cve/CVE-2016-8648  2016-11-24  https://bugzilla.redhat.com/show_bug.cgi?id=1395077  moderate   6.5    7.2     0      0  
+https://access.redhat.com/security/cve/CVE-2016-6817  2016-11-22  https://bugzilla.redhat.com/show_bug.cgi?id=1397474  important  5.0    7.5     0      0  
+https://access.redhat.com/security/cve/CVE-2016-9382  2016-11-22  https://bugzilla.redhat.com/show_bug.cgi?id=1392933  moderate   4.6    7.5     0      0  
 ```
 
+Use `-x`/`--extract-cves` to retrieve all individual CVEs found by search.
+
 ```
-$ rhsecapi --q-empty --q-pagesize 1 --extract-search --all-fields 
+$ rhsecapi --q-empty --q-pagesize 1 --extract-cves --most-fields --wrap 
 [NOTICE ] rhsda: 1 CVEs found with search query
 [NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 1 of 1
 
-CVE-2016-9401
-  SEVERITY: Low Impact
-  DATE:     2016-11-17
-  CWE:      CWE-416
-  CVSS:     3.3 (AV:L/AC:M/Au:N/C:P/I:P/A:N)
-  CVSS3:    4.4 (CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N)
-  BUGZILLA: 1396383
-  DETAILS:  
-   Details pending
-  FIX_STATES:
-   New: Red Hat Enterprise Linux 5 [bash]
-   New: Red Hat Enterprise Linux 6 [bash]
-   New: Red Hat Enterprise Linux 7 [bash]
+CVE-2016-9685
+  SEVERITY : Low Impact
+  DATE     : 2016-12-01
+  CWE      : CWE-772
+  CVSS     : 2.1 (AV:L/AC:L/Au:N/C:P/I:N/A:N)
+  CVSS3    : 3.8 (CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:L/I:N/A:N)
+  BUGZILLA : 1396941
+  FIX_STATES :
+   Will not fix: Red Hat Enterprise MRG 2 [realtime-kernel]
+   New: Red Hat Enterprise Linux 6 [kernel]
+   Will not fix: Red Hat Enterprise Linux 7 [kernel-rt]
+   Will not fix: Red Hat Enterprise Linux 7 [kernel]
 ```
 
 ### Find by attributes
+
+Can combine multiple `--q-xxx` options to find desired CVEs.
 
 ```
 $ rhsecapi --q-package rhev-hypervisor6 --q-after 2014-10-01
 [NOTICE ] rhsda: 6 CVEs found with search query
 
-CVE-2015-3456
-CVE-2015-0235
-CVE-2014-3611
-CVE-2014-3645
-CVE-2014-3646
-CVE-2014-3567
+CVE ID         PUB DATE    BUGZILLA  SEVERITY   CVSS2  CVSS3  RHSAS  PKGS
+CVE-2015-3456  2015-05-13  1218611   important  6.5            9      8  
+CVE-2015-0235  2015-01-27  1183461   critical   6.8            5     10  
+CVE-2014-3611  2014-10-21  1144878   important  5.5            5      5  
+CVE-2014-3645  2014-10-21  1144835   moderate   4.7            4      4  
+CVE-2014-3646  2014-10-21  1144825   moderate   4.7            4      4  
+CVE-2014-3567  2014-10-15  1152961   moderate   4.3            3      3  
 ```
 
-```
-$ rhsecapi --q-package rhev-hypervisor6 --q-after 2014-10-01 --count
-[NOTICE ] rhsda: 6 CVEs found with search query
-```
+Other possibilities:
 
 ```
-$ rhsecapi --q-package rhev-hypervisor6 --q-after 2014-12-01 --q-severity critical --json
-[NOTICE ] rhsda: 1 CVEs found with search query
-
-[
-  {
-    "CVE": "CVE-2015-0235", 
-    "CWE": "CWE-131->CWE-122", 
-    "advisories": [
-      "RHSA-2015:0090", 
-      "RHSA-2015:0092", 
-      "RHSA-2015:0126", 
-      "RHSA-2015:0101", 
-      "RHSA-2015:0099"
-    ], 
-    "affected_packages": [
-      "glibc-2.5-123.el5_11.1", 
-      "glibc-2.12-1.149.el6_6.5", 
-      "rhev-hypervisor6-6.6-20150123.1.el6ev", 
-      "glibc-2.17-55.el7_0.5", 
-      "glibc-2.3.4-2.57.el4.2", 
-      "glibc-2.5-107.el5_9.8", 
-      "glibc-2.12-1.107.el6_4.7", 
-      "glibc-2.12-1.132.el6_5.5", 
-      "glibc-2.5-58.el5_6.6", 
-      "glibc-2.12-1.47.el6_2.15"
-    ], 
-    "bugzilla": "1183461", 
-    "cvss_score": 6.8, 
-    "cvss_scoring_vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P", 
-    "public_date": "2015-01-27T00:00:00+00:00", 
-    "resource_url": "https://access.redhat.com/labs/securitydataapi/cve/CVE-2015-0235.json", 
-    "severity": "critical"
-  }
-]
+$ rhsecapi --q-[TabTab]
+--q-advisory  --q-bug       --q-cwe       --q-pagenum   --q-severity
+--q-after     --q-cvss      --q-empty     --q-pagesize  
+--q-before    --q-cvss3     --q-package   --q-raw       
 ```
 
+Narrowing it down ...
+
 ```
-$ rhsecapi --loglevel info --q-package rhev-hypervisor6 --q-after 2014-12-01 --q-severity critical --extract-search --product hypervisor
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve.json?after=2014-12-01&severity=critical&package=rhev-hypervisor6' ...
+$ rhsecapi --q-package rhev-hypervisor6 --q-after 2014-12-01 --q-severity critical --loglevel info --extract-cves --product hypervisor
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve.json?after=2014-12-01&severity=critical&package=rhev-hypervisor6
 [NOTICE ] rhsda: 1 CVEs found with search query
 [INFO   ] rhsda: Using 1 worker threads
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2015-0235.json' ...
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve/CVE-2015-0235.json
 [NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 1 of 1
 [NOTICE ] rhsda: Results matching spotlight-product option: 1 of 1
 
 CVE-2015-0235
-  SEVERITY: Critical Impact
-  DATE:     2015-01-27
-  BUGZILLA: 1183461
-  FIXED_RELEASES matching 'hypervisor':
-   RHEV Hypervisor for RHEL-6 [rhev-hypervisor6-6.6-20150123.1.el6ev]: RHSA-2015:0126
+  SEVERITY : Critical Impact
+  DATE     : 2015-01-27
+  BUGZILLA : 1183461
+  FIXED_RELEASES matching 'hypervisor' :
+   RHEV Hypervisor for RHEL-6: [rhev-hypervisor6-6.6-20150123.1.el6ev] via RHSA-2015:0126 (2015-02-04)
 ```
 
 
-### Find CVEs by IAVA
+### Working with IAVAs
+
+IAVAs can be retrieved instantly ...
 
 ```
-$ rhsecapi --loglevel info --q-iava not-a-real-iava
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/iavmmapper/api/iava/' ...
-[ERROR  ] rhsda: Login error
+$ rhsecapi --iava 2016-A-0287 -i 2016-A-0309 --urls 
+[NOTICE ] rhsda: Valid Red Hat IAVA results retrieved: 2 of 2
+[NOTICE ] rhsda: Number of CVEs mapped from retrieved IAVAs: 5
 
-IAVA→CVE mapping data is not provided by the public RH Security Data API.
-Instead, this uses the IAVM Mapper App (access.redhat.com/labs/iavmmapper).
+2016-A-0287 (https://access.redhat.com/labs/securitydataapi/iava?number=2016-A-0287)
+  TITLE    : Multiple Vulnerabilities in Oracle Enterprise Manager
+  SEVERITY : CAT I
+  ID       : 140611
+  CVES     :
+   CVE-2015-7940 (https://access.redhat.com/security/cve/CVE-2015-7940)
+   CVE-2016-2107 (https://access.redhat.com/security/cve/CVE-2016-2107)
+   CVE-2016-4979 (https://access.redhat.com/security/cve/CVE-2016-4979)
+   CVE-2016-5604 (https://access.redhat.com/security/cve/CVE-2016-5604)
 
-Access to this data requires RH Customer Portal credentials be provided.
-Create a ~/.netrc with the following contents:
-
-machine access.redhat.com
-  login YOUR-CUSTOMER-PORTAL-LOGIN
-  password YOUR_PASSWORD_HERE
-
-For help, open an issue at http://github.com/ryran/rhsecapi
-Or post a comment at https://access.redhat.com/discussions/2713931
-
-$ vim ~/.netrc
-
-$ rhsecapi --loglevel info --q-iava not-a-real-iava
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/iavmmapper/api/iava/' ...
-[ERROR  ] rhsda: IAVM Mapper app main index doesn't contain 'not-a-real-iava'
-
-For help, open an issue at http://github.com/ryran/rhsecapi
-Or post a comment at https://access.redhat.com/discussions/2713931
+2016-A-0309 (https://access.redhat.com/labs/securitydataapi/iava?number=2016-A-0309)
+  TITLE    : ISC BIND Remote Denial of Service Vulnerability
+  SEVERITY : CAT I
+  ID       : 140634
+  CVES     :
+   CVE-2016-8864 (https://access.redhat.com/security/cve/CVE-2016-8864)
 ```
 
-```
-$ rhsecapi --q-iava 2016-A-0287
-[NOTICE ] rhsda: 4 CVEs found with search
-
-CVE-2015-7940
-CVE-2016-2107
-CVE-2016-4979
-CVE-2016-5604
-```
+Each of the mapped CVEs can be looked up by simply adding the `-x`/`--extract-cves` option. (For brevity, the following example also uses `--product`.)
 
 ```
-$ rhsecapi --q-iava 2016-A-0287 --json --loglevel warning 
+$ rhsecapi --iava 2016-A-0287 -i 2016-A-0309 --urls --extract-cves --product 'linux 6'
+[NOTICE ] rhsda: Valid Red Hat IAVA results retrieved: 2 of 2
+[NOTICE ] rhsda: Number of CVEs mapped from retrieved IAVAs: 5
+[NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 4 of 5
+[NOTICE ] rhsda: Results matching spotlight-product option: 3 of 5
 
-{
-  "IAVM": {
-    "CVEs": {
-      "CVENumber": [
-        "CVE-2015-7940", 
-        "CVE-2016-2107", 
-        "CVE-2016-4979", 
-        "CVE-2016-5604"
-      ]
-    }, 
-    "S": {
-      "IAVM": "2016-A-0287", 
-      "Severity": "CAT I", 
-      "Title": "Multiple Vulnerabilities in Oracle Enterprise Manager"
-    }
-  }
-}
-```
+CVE-2016-8864 (https://access.redhat.com/security/cve/CVE-2016-8864)
+  SEVERITY : Important Impact (https://access.redhat.com/security/updates/classification)
+  DATE     : 2016-11-01
+  BUGZILLA : https://bugzilla.redhat.com/show_bug.cgi?id=1389652
+  FIXED_RELEASES matching 'linux 6' :
+   Red Hat Enterprise Linux 6: [bind-32:9.8.2-0.47.rc1.el6_8.3] via https://access.redhat.com/errata/RHSA-2016:2141 (2016-11-02)
 
-```
-$ rhsecapi --q-iava 2016-A-0287 --loglevel debug --extract-search --product linux.6 --count
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/iavmmapper/api/iava/' ...
-[DEBUG  ] rhsda: Return status: '200'; Content-Type: 'application/json; charset=utf-8'
-[DEBUG  ] rhsda: IAVM Mapper app main index contains '2016-A-0287'
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/iavmmapper/api/iava/2016-A-0287' ...
-[DEBUG  ] rhsda: Return status: '200'; Content-Type: 'application/json; charset=utf-8'
-[NOTICE ] rhsda: 4 CVEs found with search
-[INFO   ] rhsda: Using 4 worker threads
-[DEBUG  ] rhsda: Requested fields string: 'BASE'
-[DEBUG  ] rhsda: Enabled fields: 'threat_severity, public_date, bugzilla, affected_release, package_state'
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2015-7940.json' ...
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-2107.json' ...
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-4979.json' ...
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5604.json' ...
-[DEBUG  ] rhsda: Return status: '200'; Content-Type: 'application/json; charset=utf-8'
-[DEBUG  ] rhsda: Return status: '200'; Content-Type: 'application/json; charset=utf-8'
-[INFO   ] rhsda: Hiding CVE-2015-7940 due to negative product match
-[DEBUG  ] rhsda: Return status: '200'; Content-Type: 'application/json; charset=utf-8'
-[DEBUG  ] rhsda: Return status: '404'; Content-Type: 'text/html;charset=UTF-8'
-[INFO   ] rhsda: 404 Client Error: Not Found for url: https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5604.json
-[NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 3 of 4
-[NOTICE ] rhsda: Results matching spotlight-product option: 2 of 4
-[NOTICE ] rhsda: Invalid CVE queries: 1 of 4
-```
-
-```
-$ rhsecapi --q-iava 2016-A-0287 --extract-search --product linux.6
-[NOTICE ] rhsda: 4 CVEs found with search
-[NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 3 of 4
-[NOTICE ] rhsda: Results matching spotlight-product option: 2 of 4
-[NOTICE ] rhsda: Invalid CVE queries: 1 of 4
-
-CVE-2016-2107
-  SEVERITY: Moderate Impact
-  DATE:     2016-05-03
-  BUGZILLA: 1331426
-  FIXED_RELEASES matching 'linux.6':
-   Red Hat Enterprise Linux 6 [openssl-1.0.1e-48.el6_8.1]: RHSA-2016:0996
-  FIX_STATES matching 'linux.6':
+CVE-2016-2107 (https://access.redhat.com/security/cve/CVE-2016-2107)
+  SEVERITY : Moderate Impact (https://access.redhat.com/security/updates/classification)
+  DATE     : 2016-05-03
+  BUGZILLA : https://bugzilla.redhat.com/show_bug.cgi?id=1331426
+  FIXED_RELEASES matching 'linux 6' :
+   Red Hat Enterprise Linux 6: [openssl-1.0.1e-48.el6_8.1] via https://access.redhat.com/errata/RHSA-2016:0996 (2016-05-10)
+  FIX_STATES matching 'linux 6' :
    Not affected: Red Hat Enterprise Linux 6 [openssl098e]
 
-CVE-2016-4979
-  SEVERITY: Moderate Impact
-  DATE:     2016-07-05
-  BUGZILLA: 1352476
-  FIX_STATES matching 'linux.6':
+CVE-2016-4979 (https://access.redhat.com/security/cve/CVE-2016-4979)
+  SEVERITY : Moderate Impact (https://access.redhat.com/security/updates/classification)
+  DATE     : 2016-07-05
+  BUGZILLA : https://bugzilla.redhat.com/show_bug.cgi?id=1352476
+  FIX_STATES matching 'linux 6' :
    Not affected: Red Hat Enterprise Linux 6 [httpd]
 ```
 
@@ -523,7 +448,7 @@ CVE-2016-4979
 - **Recipe:**
 
   1. Start with a package search (`--q-package glibc`)
-  1. Extract the CVEs (`--extract-search` or `-s`)
+  1. Extract the CVEs (`--extract-cves` or `-x`)
   1. Use spotlight-product option to narrow results (`--product 'linux 6'`)
     - Note: this option treats input as a case-insensitive extended regex and matches it against two product fields in the json data; see `--help` entry for `--product`
   1. Restrict field display to exclude the `FIXED_RELEASES` field, e.g., `-f ^releases` OR specify customized list that includes `FIX_STATES` and not `FIXED_RELEASES` (e.g., `-f severity,date,cvss,states`)
@@ -532,66 +457,66 @@ CVE-2016-4979
 - **Example:**
 
   ```
-  $ rhsecapi --q-package glibc --extract-search --product 'linux 6' -f bugzilla,fix_states,severity,cvss
+  $ rhsecapi --q-package glibc --extract-cves --product 'linux 6' -f bugzilla,fix_states,severity,cvss
   [NOTICE ] rhsda: 41 CVEs found with search query
   [NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 41 of 41
   [NOTICE ] rhsda: Results matching spotlight-product option: 8 of 41
 
+  CVE-2010-0830
+    SEVERITY : Low Impact
+    CVSS     : 3.7 (AV:L/AC:H/Au:N/C:P/I:P/A:P)
+    BUGZILLA : 599056
+    FIX_STATES matching 'linux 6' :
+     Not affected: Red Hat Enterprise Linux 6 [glibc]
+
+  CVE-2015-5277
+    SEVERITY : Important Impact
+    CVSS     : 3.7 (AV:L/AC:H/Au:N/C:P/I:P/A:P)
+    BUGZILLA : 1262914
+    FIX_STATES matching 'linux 6' :
+     Not affected: Red Hat Enterprise Linux 6 [glibc]
+
   CVE-2016-3075
-    SEVERITY: Low Impact
-    CVSS:     3.7 (AV:L/AC:H/Au:N/C:P/I:P/A:P)
-    BUGZILLA: 1321866
-    FIX_STATES matching 'linux 6':
+    SEVERITY : Low Impact
+    CVSS     : 3.7 (AV:L/AC:H/Au:N/C:P/I:P/A:P)
+    BUGZILLA : 1321866
+    FIX_STATES matching 'linux 6' :
      Will not fix: Red Hat Enterprise Linux 6 [compat-glibc]
      Will not fix: Red Hat Enterprise Linux 6 [glibc]
 
-  CVE-2015-5277
-    SEVERITY: Important Impact
-    CVSS:     3.7 (AV:L/AC:H/Au:N/C:P/I:P/A:P)
-    BUGZILLA: 1262914
-    FIX_STATES matching 'linux 6':
-     Not affected: Red Hat Enterprise Linux 6 [glibc]
-
   CVE-2014-8121
-    SEVERITY: Low Impact
-    CVSS:     3.3 (AV:A/AC:L/Au:N/C:N/I:N/A:P)
-    BUGZILLA: 1165192
-    FIX_STATES matching 'linux 6':
+    SEVERITY : Low Impact
+    CVSS     : 3.3 (AV:A/AC:L/Au:N/C:N/I:N/A:P)
+    BUGZILLA : 1165192
+    FIX_STATES matching 'linux 6' :
      Fix deferred: Red Hat Enterprise Linux 6 [glibc]
 
-  CVE-2015-1472
-    SEVERITY: Low Impact
-    CVSS:     2.6 (AV:L/AC:H/Au:N/C:P/I:N/A:P)
-    BUGZILLA: 1188235
-    FIX_STATES matching 'linux 6':
+  CVE-2015-1473
+    SEVERITY : Low Impact
+    CVSS     : 2.6 (AV:L/AC:H/Au:N/C:P/I:N/A:P)
+    BUGZILLA : 1209105
+    FIX_STATES matching 'linux 6' :
      Not affected: Red Hat Enterprise Linux 6 [glibc]
 
-  CVE-2015-1473
-    SEVERITY: Low Impact
-    CVSS:     2.6 (AV:L/AC:H/Au:N/C:P/I:N/A:P)
-    BUGZILLA: 1209105
-    FIX_STATES matching 'linux 6':
+  CVE-2015-1472
+    SEVERITY : Low Impact
+    CVSS     : 2.6 (AV:L/AC:H/Au:N/C:P/I:N/A:P)
+    BUGZILLA : 1188235
+    FIX_STATES matching 'linux 6' :
      Not affected: Red Hat Enterprise Linux 6 [glibc]
 
   CVE-2010-0296
-    SEVERITY: Low Impact
-    CVSS:     4.3 (AV:L/AC:L/Au:S/C:P/I:P/A:P)
-    BUGZILLA: 559579
-    FIX_STATES matching 'linux 6':
-     Not affected: Red Hat Enterprise Linux 6 [glibc]
-
-  CVE-2010-0830
-    SEVERITY: Low Impact
-    CVSS:     3.7 (AV:L/AC:H/Au:N/C:P/I:P/A:P)
-    BUGZILLA: 599056
-    FIX_STATES matching 'linux 6':
+    SEVERITY : Low Impact
+    CVSS     : 4.3 (AV:L/AC:L/Au:S/C:P/I:P/A:P)
+    BUGZILLA : 559579
+    FIX_STATES matching 'linux 6' :
      Not affected: Red Hat Enterprise Linux 6 [glibc]
 
   CVE-2009-5029
-    SEVERITY: Moderate Impact
-    CVSS:     6.5 (AV:N/AC:L/Au:S/C:P/I:P/A:P)
-    BUGZILLA: 761245
-    FIX_STATES matching 'linux 6':
+    SEVERITY : Moderate Impact
+    CVSS     : 6.5 (AV:N/AC:L/Au:S/C:P/I:P/A:P)
+    BUGZILLA : 761245
+    FIX_STATES matching 'linux 6' :
      Affected: Red Hat Enterprise Linux 6 [compat-glibc]
   ```
 
@@ -603,7 +528,7 @@ usage: rhsecapi [--q-before YYYY-MM-DD] [--q-after YYYY-MM-DD] [--q-bug BZID]
                 [--q-advisory RHSA] [--q-severity IMPACT] [--q-package PKG]
                 [--q-cwe CWEID] [--q-cvss SCORE] [--q-cvss3 SCORE] [--q-empty]
                 [--q-pagesize PAGESZ] [--q-pagenum PAGENUM] [--q-raw RAWQUERY]
-                [--q-iava IAVA] [-s] [-0] [-f FIELDS | -a | -m] [-p PRODUCT]
+                [-i YYYY-?-NNNN] [-x] [-0] [-f FIELDS | -a | -m] [-p PRODUCT]
                 [-j] [-u] [-w [WIDTH]] [-c] [-l {debug,info,notice,warning}]
                 [-t THREDS] [-P] [-E [DAYS]] [--dryrun] [-h] [--help]
                 [CVE-YYYY-NNNN [CVE-YYYY-NNNN ...]]
@@ -638,24 +563,23 @@ FIND CVES BY ATTRIBUTE:
                         relevant when there are more than PAGESZ results
   --q-raw RAWQUERY      Narrow down results by RAWQUERY (e.g.: '--q-raw a=x
                         --q-raw b=y'); this allows passing arbitrary params
-                        (e.g. something new that is unsupported by rhsecapi)
+                        (e.g. something new that is unknown to rhsecapi)
 
-FIND CVES BY IAVA:
-  --q-iava IAVA         Narrow down results by IAVA number (e.g.:
-                        '2016-A-0293'); note however that this feature is not
-                        provided by the Red Hat Security Data API and thus:
-                        (1) it requires login to the Red Hat Customer Portal
-                        and (2) it cannot be used in concert with any of the
-                        above search parameters
+RETRIEVE SPECIFIC IAVAS:
+  -i, --iava YYYY-?-NNNN
+                        Retrieve notice details for an IAVA number; specify
+                        option multiple times to retrieve multiple IAVAs at
+                        once (use below --extract-cves option to lookup mapped
+                        CVEs)
 
-QUERY SPECIFIC CVES:
+RETRIEVE SPECIFIC CVES:
   CVE-YYYY-NNNN         Retrieve a CVE or list of CVEs (e.g.:
                         'CVE-2016-5387'); note that case-insensitive regex-
                         matching is done -- extra characters & duplicate CVEs
                         will be discarded
-  -s, --extract-search  Extract CVEs them from search query (as initiated by
-                        at least one of the --q-xxx options)
-  -0, --extract-stdin   Extract CVEs from stdin (CVEs will be matched by case-
+  -x, --extract-cves    Extract CVEs from search query (as initiated by at
+                        least one of the --q-xxx options or the --iava option)
+  -0, --stdin           Extract CVEs from stdin (CVEs will be matched by case-
                         insensitive regex 'CVE-[0-9]{4}-[0-9]{4,}' and
                         duplicates will be discarded); note that terminal
                         width auto-detection is not possible in this mode and
@@ -716,13 +640,13 @@ GENERAL OPTIONS:
                         DAYS defaults to '1' if option is used but DAYS is
                         omitted)
   --dryrun              Skip CVE retrieval; this option only makes sense in
-                        concert with --extract-stdin, for the purpose of
-                        quickly getting a printable list of CVE ids from stdin
+                        concert with --stdin, for the purpose of quickly
+                        getting a printable list of CVE ids from stdin
   -h                    Show short usage summary and exit
   --help                Show this help message and exit
 
 VERSION:
-  rhsecapi v1.0.0_rc5 last mod 2016/11/22
+  rhsecapi v1.0.0_rc8 last mod 2016/12/01
   See <http://github.com/ryran/rhsecapi> to report bugs or RFEs
 ```
 
@@ -732,61 +656,44 @@ VERSION:
 The `rhsda` library does all the work of interfacing with the API. If run directly, it tries to find CVEs on stdin.
 
 ```
-$ echo CVE-2016-9401 CVE-2016-9372 CVE-2016-8635 | python rhsda.py
-[NOTICE ] rhsda: Found 3 CVEs in stdin; 0 duplicates removed
-[INFO   ] rhsda: Using 3 worker threads
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-9401.json' ...
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-8635.json' ...
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-9372.json' ...
-[NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 3 of 3
+$ echo CVE-2016-9401 CVE-2016-9372 CVE-2016-9372 CVE-2016-9372 | python rhsda.py
+[NOTICE ] rhsda: Found 2 CVEs on stdin; 2 duplicates removed
+[INFO   ] rhsda: Using 2 worker threads
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-9401.json
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-9372.json
+[NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 2 of 2
 CVE-2016-9401
-  SEVERITY: Low Impact
-  DATE:     2016-11-17
-  CWE:      CWE-416
-  CVSS:     3.3 (AV:L/AC:M/Au:N/C:P/I:P/A:N)
-  CVSS3:    4.4 (CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N)
-  BUGZILLA: 1396383
-  DETAILS:  
-   Details pending
-  FIX_STATES:
-   New: Red Hat Enterprise Linux 5 [bash]
-   New: Red Hat Enterprise Linux 6 [bash]
-   New: Red Hat Enterprise Linux 7 [bash]
-
-CVE-2016-8635
-  SEVERITY: Moderate Impact
-  DATE:     2016-11-16
-  CVSS:     4.3 (AV:N/AC:M/Au:N/C:P/I:N/A:N)
-  CVSS3:    5.3 (CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N)
-  BUGZILLA: 1391818
-  ACKNOWLEDGEMENT:  
-   This issue was discovered by Hubert Kario (Red Hat).
-  DETAILS:  
+  SEVERITY : Low Impact
+  DATE     : 2016-11-17
+  CWE      : CWE-416
+  CVSS     : 1.9 (AV:L/AC:M/Au:N/C:N/I:N/A:P)
+  CVSS3    : 3.3 (CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L)
+  BUGZILLA : 1396383
+  DETAILS  : 
    ** RESERVED ** This candidate has been reserved by an organization
    or individual that will use it when announcing a new security
    problem.  When the candidate has been publicized, the details for
-   this candidate will be provided.  It was found that Diffie Hellman
-   Client key exchange handling in NSS was vulnerable to small
-   subgroup confinement attack. An attacker could use this flaw to
-   recover private keys by confining the client DH key to small
-   subgroup of the desired group.
-  FIXED_RELEASES:
-   Red Hat Enterprise Linux 5 [nss-3.21.3-2.el5_11]: RHSA-2016:2779
-   Red Hat Enterprise Linux 6 [nss-3.21.3-2.el6_8]: RHSA-2016:2779
-   Red Hat Enterprise Linux 7 [nss-3.21.3-2.el7_3]: RHSA-2016:2779
+   this candidate will be provided.
+  FIX_STATES :
+   Will not fix: Red Hat Enterprise Linux 5 [bash]
+   Will not fix: Red Hat Enterprise Linux 6 [bash]
+   Will not fix: Red Hat Enterprise Linux 7 [bash]
 
 CVE-2016-9372
-  SEVERITY: Moderate Impact
-  DATE:     2016-11-16
-  CVSS:     4.3 (AV:N/AC:M/Au:N/C:N/I:N/A:P)
-  CVSS3:    5.9 (CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H)
-  BUGZILLA: 1396409
-  DETAILS:  
-   Details pending
-  UPSTREAM_FIX:  wireshark 2.2.2
-  REFERENCES:
+  SEVERITY : Moderate Impact
+  DATE     : 2016-11-16
+  CVSS     : 4.3 (AV:N/AC:M/Au:N/C:N/I:N/A:P)
+  CVSS3    : 5.9 (CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H)
+  BUGZILLA : 1396409
+  DETAILS  : 
+   In Wireshark 2.2.0 to 2.2.1, the Profinet I/O dissector could loop
+   excessively, triggered by network traffic or a capture file. This
+   was addressed in plugins/profinet/packet-pn-rtc-one.c by rejecting
+   input with too many I/O objects.
+  UPSTREAM_FIX : wireshark 2.2.2
+  REFERENCES :
    https://www.wireshark.org/security/wnpa-sec-2016-58.html
-  FIX_STATES:
+  FIX_STATES :
    Will not fix: Red Hat Enterprise Linux 5 [wireshark]
    Will not fix: Red Hat Enterprise Linux 6 [wireshark]
    Will not fix: Red Hat Enterprise Linux 7 [wireshark]
@@ -804,7 +711,7 @@ NAME
     rhsda
 
 FILE
-    /usr/share/rhsecapi/rhsda.py
+    /g/dev-rhsecapi/rhsda.py
 
 DESCRIPTION
     # -*- coding: utf-8 -*-
@@ -834,7 +741,7 @@ CLASSES
      |  
      |  __init__(self, logLevel='notice')
      |  
-     |  cve_search_query(self, params, outFormat='list')
+     |  cve_search_query(self, params, outFormat='list', urls=False)
      |      Perform a CVE search query.
      |      
      |      ON *OUTFORMAT*:
@@ -847,8 +754,9 @@ CLASSES
      |  find_cves(self, params=None, outFormat='json', before=None, after=None, bug=None, advisory=None, severity=None, package=None, cwe=None, cvss_score=None, cvss3_score=None, page=None, per_page=None)
      |      Find CVEs by recent or attributes.
      |      
-     |      Provides an index to recent CVEs when no parameters are passed. Returns a
-     |      convenience object as response with minimal attributes. 
+     |      Provides an index to recent CVEs when no parameters are passed.
+     |      Each list item is a convenience object with minimal attributes.
+     |      Use parameters to narrow down results.
      |      
      |      With *outFormat* of "json", returns JSON object.
      |      With *outFormat* of "xml", returns unformatted XML as string.
@@ -857,9 +765,20 @@ CLASSES
      |  find_cvrfs(self, params=None, outFormat='json', before=None, after=None, bug=None, cve=None, severity=None, package=None, page=None, per_page=None)
      |      Find CVRF documents by recent or attributes.
      |      
-     |      Provides an index to recent CVRF documents with a summary of their contents,
-     |      when no parameters are passed. Returns a convenience object as the response with
-     |      minimal attributes. 
+     |      Provides an index to recent CVRF documents when no parameters are passed.
+     |      Each list item is a convenience object with minimal attributes.
+     |      Use parameters to narrow down results.
+     |      
+     |      With *outFormat* of "json", returns JSON object.
+     |      With *outFormat* of "xml", returns unformatted XML as string.
+     |      If *params* dict is passed, additional parameters are ignored.
+     |  
+     |  find_iavas(self, params=None, outFormat='json', number=None, severity=None, page=None, per_page=None)
+     |      Find IAVA notices by recent or attributes.
+     |      
+     |      Provides an index to recent IAVA notices when no parameters are passed.
+     |      Each list item is a convenience object with minimal attributes.
+     |      Use parameters to narrow down results.
      |      
      |      With *outFormat* of "json", returns JSON object.
      |      With *outFormat* of "xml", returns unformatted XML as string.
@@ -868,9 +787,9 @@ CLASSES
      |  find_ovals(self, params=None, outFormat='json', before=None, after=None, bug=None, cve=None, severity=None, page=None, per_page=None)
      |      Find OVAL definitions by recent or attributes.
      |      
-     |      Provides an index to recent OVAL definitions with a summary of their contents,
-     |      when no parameters are passed. Returns a convenience object as the response with
-     |      minimal attributes.
+     |      Provides an index to recent OVAL definitions when no parameters are passed.
+     |      Each list item is a convenience object with minimal attributes.
+     |      Use parameters to narrow down results.
      |      
      |      With *outFormat* of "json", returns JSON object.
      |      With *outFormat* of "xml", returns unformatted XML as string.
@@ -885,8 +804,8 @@ CLASSES
      |  get_cvrf_oval(self, rhsa, outFormat='json')
      |      Retrieve CVRF-OVAL details for an RHSA.
      |  
-     |  get_iava(self, iavaId)
-     |      Validate IAVA number and return json.
+     |  get_iava(self, iava, outFormat='json')
+     |      Retrieve notice details for an IAVA.
      |  
      |  get_oval(self, rhsa, outFormat='json')
      |      Retrieve OVAL details for an RHSA.
@@ -894,7 +813,7 @@ CLASSES
      |  mget_cves(self, cves, numThreads=0, onlyCount=False, outFormat='plaintext', urls=False, fields='ALL', wrapWidth=70, product=None, timeout=300)
      |      Use multi-threading to lookup a list of CVEs and return text output.
      |      
-     |      *cves*:       A list of CVE ids or a str obj from which to regex CVE ids
+     |      *cves*:       A list of CVE ids or a str/file obj from which to regex CVE ids
      |      *numThreads*: Number of concurrent worker threads; 0 == CPUs*2
      |      *onlyCount*:  Whether to exit after simply logging number of valid/invalid CVEs
      |      *outFormat*:  Control output format ("plaintext", "json", or "jsonpretty")
@@ -947,16 +866,33 @@ CLASSES
      |          fields="^releases,mitigation"
      |      
      |      Finally: *fields* is case-insensitive.
+     |  
+     |  mget_iavas(self, iavas, numThreads=0, onlyCount=False, outFormat='plaintext', urls=False, timeout=300)
+     |      Use multi-threading to lookup a list of IAVAs and return text output.
+     |      
+     |      *iavas*:      A list of IAVA ids
+     |      *numThreads*: Number of concurrent worker threads; 0 == CPUs*2
+     |      *onlyCount*:  Whether to exit after simply logging number of valid/invalid CVEs
+     |      *outFormat*:  Control output format ("list", "plaintext", "json", or "jsonpretty")
+     |      *urls*:       Whether to add extra URLs to certain fields
+     |      *timeout*:    Total ammount of time to wait for all CVEs to be retrieved
+     |      
+     |      ON *OUTFORMAT*:
+     |      
+     |      Setting to "list" returns list object containing ONLY CVE ids.
+     |      Setting to "plaintext" returns str object containing formatted output.
+     |      Setting to "json" returns list object (i.e., original JSON)
+     |      Setting to "jsonpretty" returns str object containing prettified JSON
 
 FUNCTIONS
-    extract_cves_from_input(obj)
+    extract_cves_from_input(obj, descriptiveNoun=None)
         Use case-insensitive regex to extract CVE ids from input object.
         
         *obj* can be a list, a file, or a string.
         
         A list of CVEs is returned.
     
-    jprint(jsoninput, printOutput=True)
+    jprint(jsoninput)
         Pretty-print jsoninput.
 
 DATA
@@ -1051,22 +987,22 @@ Also available: multi-threaded CVE retrieval (with default conversion to pretty-
 ```
 >>> a = rhsda.ApiClient('info')    # (This increases the console loglevel [stderr])
 >>> txt = a.mget_cves("CVE-2016-5387 CVE-2016-5392")
-[NOTICE ] rhsda: Found 2 CVEs in input; 0 duplicates removed
+[NOTICE ] rhsda: Found 2 CVEs on input
 [INFO   ] rhsda: Using 2 worker threads
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5392.json' ...
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5387.json' ...
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5392.json
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5387.json
 [NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 2 of 2
 >>> print(txt)
 CVE-2016-5392
-  SEVERITY: Important Impact
-  DATE:     2016-07-14
-  CWE:      CWE-20
-  CVSS:     6.8 (AV:N/AC:L/Au:S/C:C/I:N/A:N)
-  CVSS3:    6.5 (CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N)
-  BUGZILLA: 1356195
-  ACKNOWLEDGEMENT:  
+  SEVERITY : Important Impact
+  DATE     : 2016-07-14
+  CWE      : CWE-20
+  CVSS     : 6.8 (AV:N/AC:L/Au:S/C:C/I:N/A:N)
+  CVSS3    : 6.5 (CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N)
+  BUGZILLA : 1356195
+  ACKNOWLEDGEMENT :  
    This issue was discovered by Yanping Zhang (Red Hat).
-  DETAILS:  
+  DETAILS  : 
    The API server in Kubernetes, as used in Red Hat OpenShift
    Enterprise 3.2, in a multi tenant environment allows remote
    authenticated users with knowledge of other project names to obtain
@@ -1076,23 +1012,23 @@ CVE-2016-5392
    OpenShift Enterprise may return data for other users and projects
    when queried by a user. An attacker with knowledge of other project
    names could use this vulnerability to view their information.
-  FIXED_RELEASES:
-   Red Hat OpenShift Enterprise 3.2 [atomic-openshift-3.2.1.7-1.git.0.2702170.el7]: RHSA-2016:1427
-  FIX_STATES:
+  FIXED_RELEASES :
+   Red Hat OpenShift Enterprise 3.2: [atomic-openshift-3.2.1.7-1.git.0.2702170.el7] via RHSA-2016:1427 (2016-07-14)
+  FIX_STATES :
    Affected: Red Hat OpenShift Enterprise 3 [Security]
 
 CVE-2016-5387
-  SEVERITY: Important Impact
-  DATE:     2016-07-18
-  IAVA:     2016-B-0160
-  CWE:      CWE-20
-  CVSS:     5.0 (AV:N/AC:L/Au:N/C:N/I:P/A:N)
-  CVSS3:    5.0 (CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:L/A:N)
-  BUGZILLA: 1353755
-  ACKNOWLEDGEMENT:  
+  SEVERITY : Important Impact
+  DATE     : 2016-07-18
+  IAVA     : 2016-B-0160
+  CWE      : CWE-20
+  CVSS     : 5.0 (AV:N/AC:L/Au:N/C:N/I:P/A:N)
+  CVSS3    : 5.0 (CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:L/A:N)
+  BUGZILLA : 1353755
+  ACKNOWLEDGEMENT :  
    Red Hat would like to thank Scott Geary (VendHQ) for reporting this
    issue.
-  DETAILS:  
+  DETAILS  : 
    The Apache HTTP Server through 2.4.23 follows RFC 3875 section
    4.1.18 and therefore does not protect applications from the
    presence of untrusted client data in the HTTP_PROXY environment
@@ -1108,27 +1044,27 @@ CVE-2016-5387
    for outgoing HTTP requests. A remote attacker could possibly use
    this flaw to redirect HTTP requests performed by a CGI script to an
    attacker-controlled proxy via a malicious HTTP request.
-  UPSTREAM_FIX:  httpd 2.4.24, httpd 2.2.32
-  REFERENCES:
+  UPSTREAM_FIX : httpd 2.4.24, httpd 2.2.32
+  REFERENCES :
    https://access.redhat.com/security/vulnerabilities/httpoxy
    https://httpoxy.org/
    https://www.apache.org/security/asf-httpoxy-response.txt
-  FIXED_RELEASES:
-   Red Hat Enterprise Linux 5 [httpd-2.2.3-92.el5_11]: RHSA-2016:1421
-   Red Hat Enterprise Linux 6 [httpd-2.2.15-54.el6_8]: RHSA-2016:1421
-   Red Hat Enterprise Linux 7 [httpd-2.4.6-40.el7_2.4]: RHSA-2016:1422
-   Red Hat JBoss Core Services 1: RHSA-2016:1625
-   Red Hat JBoss Core Services on RHEL 6 Server [jbcs-httpd24-httpd-2.4.6-77.SP1.jbcs.el6]: RHSA-2016:1851
-   Red Hat JBoss Core Services on RHEL 7 Server [jbcs-httpd24-httpd-2.4.6-77.SP1.jbcs.el7]: RHSA-2016:1851
-   Red Hat JBoss Enterprise Web Server 2 for RHEL 6 Server [httpd-2.2.26-54.ep6.el6]: RHSA-2016:1649
-   Red Hat JBoss Enterprise Web Server 2 for RHEL 7 Server [httpd22-2.2.26-56.ep6.el7]: RHSA-2016:1648
-   Red Hat JBoss Web Server 2.1: RHSA-2016:1650
-   Red Hat JBoss Web Server 3.0: RHSA-2016:1624
-   Red Hat JBoss Web Server 3.0 for RHEL 6: RHSA-2016:1636
-   Red Hat JBoss Web Server 3.0 for RHEL 7: RHSA-2016:1635
-   Red Hat Software Collections for Red Hat Enterprise Linux Server (v. 6) [httpd24-httpd-2.4.18-11.el6]: RHSA-2016:1420
-   Red Hat Software Collections for Red Hat Enterprise Linux Server (v. 7) [httpd24-httpd-2.4.18-11.el7]: RHSA-2016:1420
-  FIX_STATES:
+  FIXED_RELEASES :
+   Red Hat Enterprise Linux 5: [httpd-2.2.3-92.el5_11] via RHSA-2016:1421 (2016-07-18)
+   Red Hat Enterprise Linux 6: [httpd-2.2.15-54.el6_8] via RHSA-2016:1421 (2016-07-18)
+   Red Hat Enterprise Linux 7: [httpd-2.4.6-40.el7_2.4] via RHSA-2016:1422 (2016-07-18)
+   Red Hat JBoss Core Services 1: via RHSA-2016:1625 (2016-08-17)
+   Red Hat JBoss Core Services on RHEL 6 Server: [jbcs-httpd24-httpd-2.4.6-77.SP1.jbcs.el6] via RHSA-2016:1851 (2016-09-12)
+   Red Hat JBoss Core Services on RHEL 7 Server: [jbcs-httpd24-httpd-2.4.6-77.SP1.jbcs.el7] via RHSA-2016:1851 (2016-09-12)
+   Red Hat JBoss Enterprise Web Server 2 for RHEL 6 Server: [httpd-2.2.26-54.ep6.el6] via RHSA-2016:1649 (2016-08-22)
+   Red Hat JBoss Enterprise Web Server 2 for RHEL 7 Server: [httpd22-2.2.26-56.ep6.el7] via RHSA-2016:1648 (2016-08-22)
+   Red Hat JBoss Web Server 2.1: via RHSA-2016:1650 (2016-08-22)
+   Red Hat JBoss Web Server 3.0: via RHSA-2016:1624 (2016-08-17)
+   Red Hat JBoss Web Server 3.0 for RHEL 6: via RHSA-2016:1636 (2016-08-18)
+   Red Hat JBoss Web Server 3.0 for RHEL 7: via RHSA-2016:1635 (2016-08-18)
+   Red Hat Software Collections for Red Hat Enterprise Linux Server (v. 6): [httpd24-httpd-2.4.18-11.el6] via RHSA-2016:1420 (2016-07-18)
+   Red Hat Software Collections for Red Hat Enterprise Linux Server (v. 7): [httpd24-httpd-2.4.18-11.el7] via RHSA-2016:1420 (2016-07-18)
+  FIX_STATES :
    Affected: Red Hat JBoss EAP 6 [httpd22]
    Not affected: Red Hat JBoss EAP 7 [httpd22]
    Will not fix: Red Hat JBoss EWS 1 [httpd]
@@ -1140,12 +1076,12 @@ The `mget_cves()` method's `cves=` argument (the 1st kwarg) regex-finds CVEs in 
 >>> s = "Hello thar we need CVE-2016-5387 fixed as well as CVE-2016-5392(worst).\nAnd not to mention CVE-2016-2379,CVE-2016-1000219please."
 >>> a = rhsda.ApiClient('info')
 >>> json = a.mget_cves(s, outFormat='json')
-[NOTICE ] rhsda: Found 4 CVEs in input; 0 duplicates removed
+[NOTICE ] rhsda: Found 4 CVEs on input
 [INFO   ] rhsda: Using 4 worker threads
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5392.json' ...
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-1000219.json' ...
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5387.json' ...
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-2379.json' ...
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5392.json
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-1000219.json
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5387.json
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-2379.json
 [NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 4 of 4
 ```
 
@@ -1156,9 +1092,8 @@ The `mget_cves()` method's `cves=` argument (the 1st kwarg) regex-finds CVEs in 
 >>> with open('scan-results.csv') as f:
 ...     txt = a.mget_cves(f)
 ... 
-[NOTICE ] rhsda: Found 150 CVEs in input; 698 duplicates removed
+[NOTICE ] rhsda: Found 150 CVEs on input; 698 duplicates removed
 [NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 148 of 150
-[NOTICE ] rhsda: Invalid CVE queries: 2 of 150
 ```
 
 Also of course a list is fine:
@@ -1167,35 +1102,36 @@ Also of course a list is fine:
 >>> L = ['CVE-2016-5387', 'CVE-2016-5392', 'CVE-2016-2379', 'CVE-2016-5773']
 >>> print(a.mget_cves(L, fields='BASE', product='web.server.3'))
 [INFO   ] rhsda: Using 4 worker threads
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5387.json' ...
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5392.json' ...
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-2379.json' ...
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5773.json' ...
-[INFO   ] rhsda: Hiding CVE-2016-5392 due to negative product match
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5387.json
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5392.json
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-2379.json
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve/CVE-2016-5773.json
 [INFO   ] rhsda: Hiding CVE-2016-2379 due to negative product match
 [INFO   ] rhsda: Hiding CVE-2016-5773 due to negative product match
+[INFO   ] rhsda: Hiding CVE-2016-5392 due to negative product match
 [NOTICE ] rhsda: Valid Red Hat CVE results retrieved: 4 of 4
 [NOTICE ] rhsda: Results matching spotlight-product option: 1 of 4
 CVE-2016-5387
-  SEVERITY: Important Impact
-  DATE:     2016-07-18
-  BUGZILLA: 1353755
-  FIXED_RELEASES matching 'web.server.3':
-   Red Hat JBoss Web Server 3.0: RHSA-2016:1624
-   Red Hat JBoss Web Server 3.0 for RHEL 6: RHSA-2016:1636
-   Red Hat JBoss Web Server 3.0 for RHEL 7: RHSA-2016:1635
+  SEVERITY : Important Impact
+  DATE     : 2016-07-18
+  BUGZILLA : 1353755
+  FIXED_RELEASES matching 'web.server.3' :
+   Red Hat JBoss Web Server 3.0: via RHSA-2016:1624 (2016-08-17)
+   Red Hat JBoss Web Server 3.0 for RHEL 6: via RHSA-2016:1636 (2016-08-18)
+   Red Hat JBoss Web Server 3.0 for RHEL 7: via RHSA-2016:1635 (2016-08-18)
 ```
 
-There's also a convenience `cve_search_query()` method but that might go away.
+There's also a convenience `cve_search_query()` method.
 
 ```
 >>> txt = a.cve_search_query({'after':'2015-01-01', 'before':'2015-02-01', 'per_page':5}, outFormat='plaintext')
-[INFO   ] rhsda: Getting 'https://access.redhat.com/labs/securitydataapi/cve.json?per_page=5&after=2015-01-01&before=2015-02-01' ...
+[INFO   ] rhsda: Getting https://access.redhat.com/labs/securitydataapi/cve.json?per_page=5&after=2015-01-01&before=2015-02-01
 [NOTICE ] rhsda: 5 CVEs found with search query
 >>> print(txt)
-CVE-2014-0141
-CVE-2015-1563
-CVE-2015-8779
-CVE-2014-9749
-CVE-2015-0210
+CVE ID         PUB DATE    BUGZILLA  SEVERITY  CVSS2  CVSS3  RHSAS  PKGS
+CVE-2014-0141  2015-01-29  1187466   moderate  4.3            0      0  
+CVE-2015-1563  2015-01-29  1187153   low       2.1            0      0  
+CVE-2015-8779  2015-01-29  1300312   moderate  5.1            0      0  
+CVE-2014-9749  2015-01-28  1186768   moderate  4.0            0      0  
+CVE-2015-0210  2015-01-28  1178921   moderate  5.4            0      0  
 ```

--- a/rhsda.py
+++ b/rhsda.py
@@ -429,16 +429,16 @@ class ApiClient:
             u = ""
             if self.cfg.urls:
                 u = " (https://access.redhat.com/security/updates/classification)"
-            out.append("  SEVERITY: {0} Impact{1}".format(J['threat_severity'], u))
+            out.append("  SEVERITY : {0} Impact{1}".format(J['threat_severity'], u))
         # PUBLIC_DATE
         if self.__check_field('public_date', J):
-            out.append("  DATE:     {0}".format(J['public_date'].split("T")[0]))
+            out.append("  DATE     : {0}".format(J['public_date'].split("T")[0]))
         # IAVA
         if self.__check_field('iava', J):
-            out.append("  IAVA:     {0}".format(J['iava']))
+            out.append("  IAVA     : {0}".format(J['iava']))
         # CWE ID
         if self.__check_field('cwe', J):
-            out.append("  CWE:      {0}".format(J['cwe']))
+            out.append("  CWE      : {0}".format(J['cwe']))
             if self.cfg.urls:
                 cwes = re.findall("CWE-[0-9]+", J['cwe'])
                 if len(cwes) == 1:
@@ -451,13 +451,13 @@ class ApiClient:
             vector = J['cvss']['cvss_scoring_vector']
             if self.cfg.urls:
                 vector = "http://nvd.nist.gov/cvss.cfm?version=2&vector={0}".format(vector)
-            out.append("  CVSS:     {0} ({1})".format(J['cvss']['cvss_base_score'], vector))
+            out.append("  CVSS     : {0} ({1})".format(J['cvss']['cvss_base_score'], vector))
         # CVSS3
         if self.__check_field('cvss3', J):
             vector = J['cvss3']['cvss3_scoring_vector']
             if self.cfg.urls:
                 vector = "https://www.first.org/cvss/calculator/3.0#{0}".format(vector)
-            out.append("  CVSS3:    {0} ({1})".format(J['cvss3']['cvss3_base_score'], vector))
+            out.append("  CVSS3    : {0} ({1})".format(J['cvss3']['cvss3_base_score'], vector))
         # BUGZILLA
         if 'bugzilla' in self.cfg.desiredFields:
             if J.has_key('bugzilla'):
@@ -465,35 +465,35 @@ class ApiClient:
                     bug = J['bugzilla']['url']
                 else:
                     bug = J['bugzilla']['id']
-                out.append("  BUGZILLA: {0}".format(bug))
+                out.append("  BUGZILLA : {0}".format(bug))
             else:
-                out.append("  BUGZILLA: No Bugzilla data")
+                out.append("  BUGZILLA : No Bugzilla data")
                 out.append("   Too new or too old? See: https://bugzilla.redhat.com/show_bug.cgi?id=CVE_legacy")
         # ACKNOWLEDGEMENT
         if self.__check_field('acknowledgement', J):
-            out.append("  ACKNOWLEDGEMENT:  {0}".format(self.__stripjoin(J['acknowledgement'])))
+            out.append("  ACKNOWLEDGEMENT :  {0}".format(self.__stripjoin(J['acknowledgement'])))
         # DETAILS
         if self.__check_field('details', J):
-            out.append("  DETAILS:  {0}".format(self.__stripjoin(J['details'])))
+            out.append("  DETAILS : {0}".format(self.__stripjoin(J['details'])))
         # STATEMENT
         if self.__check_field('statement', J):
-            out.append("  STATEMENT:  {0}".format(self.__stripjoin(J['statement'])))
+            out.append("  STATEMENT : {0}".format(self.__stripjoin(J['statement'])))
         # MITIGATION
         if self.__check_field('mitigation', J):
-            out.append("  MITIGATION:  {0}".format(self.__stripjoin(J['mitigation'])))
+            out.append("  MITIGATION : {0}".format(self.__stripjoin(J['mitigation'])))
         # UPSTREAM FIX
         if self.__check_field('upstream_fix', J):
-            out.append("  UPSTREAM_FIX:  {0}".format(J['upstream_fix']))
+            out.append("  UPSTREAM_FIX : {0}".format(J['upstream_fix']))
         # REFERENCES
         if self.__check_field('references', J):
-            out.append("  REFERENCES:{0}".format(self.__stripjoin(J['references'], oneLineEach=True)))
+            out.append("  REFERENCES :{0}".format(self.__stripjoin(J['references'], oneLineEach=True)))
         # AFFECTED RELEASE
         foundProduct_affected_release = False
         if self.__check_field('affected_release', J):
             if self.cfg.product:
-                out.append("  FIXED_RELEASES matching '{0}':".format(self.cfg.product))
+                out.append("  FIXED_RELEASES matching '{0}' :".format(self.cfg.product))
             else:
-                out.append("  FIXED_RELEASES:")
+                out.append("  FIXED_RELEASES :")
             affected_release = J['affected_release']
             if isinstance(affected_release, dict):
                 # When there's only one, it doesn't show up in a list
@@ -511,7 +511,7 @@ class ApiClient:
                 advisory = release['advisory']
                 if self.cfg.urls:
                     advisory = "https://access.redhat.com/errata/{0}".format(advisory)
-                out.append("   {0}{1}: {2}".format(release['product_name'], pkg, advisory))
+                out.append("   {0}:{1} via {2} ({3})".format(release['product_name'], pkg, advisory, release['release_date'].split("T")[0]))
             if self.cfg.product and not foundProduct_affected_release:
                 # If nothing found, remove the "FIXED_RELEASES" heading
                 out.pop()
@@ -519,9 +519,9 @@ class ApiClient:
         foundProduct_package_state = False
         if self.__check_field('package_state', J):
             if self.cfg.product:
-                out.append("  FIX_STATES matching '{0}':".format(self.cfg.product))
+                out.append("  FIX_STATES matching '{0}' :".format(self.cfg.product))
             else:
-                out.append("  FIX_STATES:")
+                out.append("  FIX_STATES :")
             package_state = J['package_state']
             if isinstance(package_state, dict):
                 # When there's only one, it doesn't show up in a list
@@ -578,26 +578,34 @@ class ApiClient:
         if self.cfg.outFormat.startswith('json'):
             return True, J
         # If CVE list output requested
-        if self.cfg.outFormat == 'list':
+        elif self.cfg.outFormat == 'list':
             cves = J['cvelist']
             if cves:
                 return True, cves
             else:
                 return None, []
-        # IAVA ID
-        out.append(iava)
-        # SEVERITY
-        out.append("  SEVERITY: {0}".format(J['severity']))
+        # Return no output if only counting
+        elif self.cfg.onlyCount:
+            return True, ""
+        # IAVA NUMBER
+        u = ""
+        if self.cfg.urls:
+            u = " ({0}/iava?number={1})".format(self.cfg.apiUrl, iava)
+        out.append("{0}{1}".format(iava, u))
         # TITLE
-        out.append("  TITLE: {0}".format(self.__stripjoin(J['title'])))
+        out.append("  TITLE    : {0}".format(J['title']))
+        # SEVERITY
+        out.append("  SEVERITY : {0}".format(J['severity']))
+        # ID
+        out.append("  ID       : {0}".format(J['id']))
         # CVELIST
         if J['cvelist']:
-            out.append("  CVES:")
+            out.append("  CVES     :")
             for cve in J['cvelist']:
-                out.append("   {0}".format(cve))
-        # Return no output if only counting
-        if self.cfg.onlyCount:
-            return True, ""
+                u = ""
+                if self.cfg.urls:
+                    u = " (https://access.redhat.com/security/cve/{0})".format(cve)
+                out.append("   {0}{1}".format(cve, u))
         # Add one final newline to the end
         out.append("")
         return True, "\n".join(out)
@@ -792,14 +800,14 @@ class ApiClient:
             return jprint(cveOutput)
 
     def mget_iavas(self, iavas, numThreads=0, onlyCount=False, outFormat='plaintext',
-                   wrapWidth=70, timeout=300):
+                   urls=False, timeout=300):
         """Use multi-threading to lookup a list of IAVAs and return text output.
 
         *iavas*:      A list of IAVA ids
         *numThreads*: Number of concurrent worker threads; 0 == CPUs*2
         *onlyCount*:  Whether to exit after simply logging number of valid/invalid CVEs
         *outFormat*:  Control output format ("list", "plaintext", "json", or "jsonpretty")
-        *wrapWidth*:  Width for long fields; 1 auto-detects based on terminal size
+        *urls*:       Whether to add extra URLs to certain fields
         *timeout*:    Total ammount of time to wait for all CVEs to be retrieved
 
         ON *OUTFORMAT*:
@@ -823,7 +831,7 @@ class ApiClient:
         # Set cfg directives for our worker
         self.cfg.onlyCount = onlyCount
         self.cfg.outFormat = outFormat
-        self._set_cve_plaintext_width(wrapWidth)
+        self.cfg.urls = urls
         # Disable sigint before starting process pool
         original_sigint_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
         pool = multiprocessing.Pool(processes=numThreads)

--- a/rhsda.py
+++ b/rhsda.py
@@ -772,12 +772,9 @@ class ApiClient:
         n_total = len(cves)
         n_hidden = successValues.count(None)
         n_valid = successValues.count(True)
-        n_invalid = successValues.count(False)
         logger.log(25, "Valid Red Hat CVE results retrieved: {0} of {1}".format(n_valid + n_hidden, n_total))
         if product:
             logger.log(25, "Results matching spotlight-product option: {0} of {1}".format(n_valid, n_total))
-        if n_invalid:
-            logger.log(25, "Invalid CVE queries: {0} of {1}".format(n_invalid, n_total))
         if onlyCount:
             return
         if outFormat == 'plaintext':
@@ -848,10 +845,7 @@ class ApiClient:
         n_total = len(iavas)
         n_hidden = successValues.count(None)
         n_valid = successValues.count(True)
-        n_invalid = successValues.count(False)
         logger.log(25, "Valid Red Hat IAVA results retrieved: {0} of {1}".format(n_valid + n_hidden, n_total))
-        if n_invalid:
-            logger.log(25, "Invalid IAVA queries: {0} of {1}".format(n_invalid, n_total))
         logger.log(25, "Number of CVEs mapped from retrieved IAVAs: {0}".format(sum(numCves)))
         if outFormat == 'list':
             cves = []

--- a/rhsda.py
+++ b/rhsda.py
@@ -153,14 +153,14 @@ def extract_cves_from_input(obj, descriptiveNoun=None):
     if found:
         matchCount = len(found)
         # Converting to a set removes duplicates
-        found = list(set(found))
+        found = list(set([x.upper() for x in found]))
         uniqueCount = len(found)
         if matchCount-uniqueCount:
             dupes = "; {0} duplicates removed".format(matchCount-uniqueCount)
         else:
             dupes = ""
         logger.log(25, "Found {0} CVEs on {1}{2}".format(uniqueCount, descriptiveNoun, dupes))
-        return [x.upper() for x in found]
+        return found
     else:
         logger.warning("No CVEs (matching regex: '{0}') found on {1}".format(cve_regex_string, descriptiveNoun))
         return []

--- a/rhsda.py
+++ b/rhsda.py
@@ -365,19 +365,17 @@ class ApiClient:
         """Strip whitespace from input or input list."""
         text = ""
         if isinstance(input, list):
-            for i in input:
-                text += i.encode('utf-8').strip()
-                if oneLineEach:
-                    text += "\n"
-                else:
-                    text += "  "
+            if oneLineEach:
+                text = "\n".join(input).encode('utf-8').strip()
+            else:
+                text = "  ".join(input).encode('utf-8').strip()
         else:
             text = input.encode('utf-8').strip()
         if oneLineEach:
             text = "\n" + text
-            text = re.sub(r"\n+", "\n   ", text)
+            text = re.sub(r"\n[\n\s]*", "\n   ", text)
         else:
-            text = re.sub(r"\n+", "  ", text)
+            text = re.sub(r"\n[\n\s]*", "  ", text)
             if self.wrapper:
                 text = "\n" + "\n".join(self.wrapper.wrap(text))
         return text
@@ -445,7 +443,7 @@ class ApiClient:
                     out[-1] += " (http://cwe.mitre.org/data/definitions/{0}.html)".format(cwes[0].lstrip("CWE-"))
                 else:
                     for c in cwes:
-                        out.append("            (http://cwe.mitre.org/data/definitions/{0}.html)".format(c.lstrip("CWE-")))
+                        out.append("             (http://cwe.mitre.org/data/definitions/{0}.html)".format(c.lstrip("CWE-")))
         # CVSS2
         if self.__check_field('cvss', J):
             vector = J['cvss']['cvss_scoring_vector']

--- a/rhsecapi.py
+++ b/rhsecapi.py
@@ -46,7 +46,7 @@ if not (path.isfile(path.expanduser('~/.rhsecapi-no-argcomplete')) or path.isfil
 prog = 'rhsecapi'
 vers = {}
 vers['version'] = '1.0.0_rc8'
-vers['date'] = '2016/11/29'
+vers['date'] = '2016/12/01'
 
 
 # Logging
@@ -307,9 +307,12 @@ def parse_args():
         o.doSearch = False
     else:
         o.doSearch = True
-    # if o.q_iava and o.doSearch:
-    #     logger.error("The --q-iava option is incompatible with other --q-xxx options; it can only be used alone")
-    #     sys.exit(1)
+        if o.iavas:
+            print("{0}: error: --q-xxx options not allowed in concert with -i/--iava".format(prog), file=sys.stderr)
+            sys.exit(1)
+        if o.cves or o.stdin:
+            print("{0}: error: --q-xxx options not allowed in concert with CVE args".format(prog), file=sys.stderr)
+            sys.exit(1)
     if o.cves:
         o.cves = rhsda.extract_cves_from_input(o.cves, "cmdline")
         if not o.cves:
@@ -319,7 +322,7 @@ def parse_args():
         o.cves.extend(found)
     # If no search (--q-xxx) and no CVEs mentioned
     if not o.showUsage and not (o.doSearch or o.cves or o.iavas):
-        logger.error("Must specify a search to perform (one of the --q-xxx opts) or CVEs or IAVAs to retrieve")
+        logger.error("Must specify CVEs/IAVAs to retrieve or a search to perform (--q-xxx opts)")
         o.showUsage = True
     if o.showUsage:
         p.print_usage()

--- a/rhsecapi.py
+++ b/rhsecapi.py
@@ -366,7 +366,7 @@ def main(opts):
                                           numThreads=opts.threads,
                                           onlyCount=opts.count,
                                           outFormat=oF,
-                                          wrapWidth=opts.wrapWidth)
+                                          urls=opts.printUrls)
         if iavaOutput:
             if opts.extract_search:
                 opts.cves.extend(iavaOutput)

--- a/rhsecapi.py
+++ b/rhsecapi.py
@@ -338,7 +338,9 @@ def parse_args():
 
 def main(opts):
     apiclient = rhsda.ApiClient(opts.loglevel)
-    # apiclient.cfg.apiUrl = 'https://accessci.usersys.redhat.com/labs/securitydataapi'
+    from os import environ
+    if environ.has_key('RHSDA_URL') and environ['RHSDA_URL'].startswith('http'):
+        apiclient.cfg.apiUrl = environ['RHSDA_URL']
     searchOutput = ""
     iavaOutput = ""
     cveOutput = ""

--- a/rhsecapi.py
+++ b/rhsecapi.py
@@ -216,7 +216,7 @@ def parse_args():
         '-s', '--extract-search', action='store_true',
         help="Extract CVEs from search query (as initiated by at least one of the --q-xxx options or the --iava option)")
     g_getCve.add_argument(
-        '-0', '--extract-stdin', action='store_true',
+        '-0', '--stdin', action='store_true',
         help="Extract CVEs from stdin (CVEs will be matched by case-insensitive regex '{0}' and duplicates will be discarded); note that terminal width auto-detection is not possible in this mode and WIDTH defaults to '70' (but can be overridden with '--width')".format(rhsda.cve_regex_string))
     # New group
     g_cveDisplay = p.add_argument_group(
@@ -265,7 +265,7 @@ def parse_args():
         help="Set time in days after which paste will be deleted (defaults to '28'; specify '0' to disable expiration; DAYS defaults to '1' if option is used but DAYS is omitted)")
     g_general.add_argument(
         '--dryrun', action='store_true',
-        help="Skip CVE retrieval; this option only makes sense in concert with --extract-stdin, for the purpose of quickly getting a printable list of CVE ids from stdin")
+        help="Skip CVE retrieval; this option only makes sense in concert with --stdin, for the purpose of quickly getting a printable list of CVE ids from stdin")
     g_general.add_argument(
         '-h', dest='showUsage', action='store_true',
         help="Show short usage summary and exit")
@@ -314,7 +314,7 @@ def parse_args():
         o.cves = rhsda.extract_cves_from_input(o.cves, "cmdline")
         if not o.cves:
             o.showUsage = True
-    if o.extract_stdin and not sys.stdin.isatty():
+    if o.stdin and not sys.stdin.isatty():
         found = rhsda.extract_cves_from_input(sys.stdin)
         o.cves.extend(found)
     # If no search (--q-xxx) and no CVEs mentioned

--- a/rhsecapi.py
+++ b/rhsecapi.py
@@ -373,13 +373,20 @@ def main(opts):
             if not opts.pastebin:
                 print(file=sys.stderr)
                 print(iavaOutput, end="")
-    if opts.dryrun and opts.cves:
-        logger.log(25, "Skipping CVE retrieval due to --dryrun; would have retrieved: {0}".format(len(opts.cves)))
-        cveOutput = " ".join(opts.cves) + "\n"
-    elif opts.cves:
-        if searchOutput or iavaOutput:
-            print(file=sys.stderr)
-        cveOutput = apiclient.mget_cves(cves=opts.cves, numThreads=opts.threads, onlyCount=opts.count, outFormat=opts.outFormat, urls=opts.printUrls, fields=opts.fields, wrapWidth=opts.wrapWidth, product=opts.product)
+    if opts.cves:
+        originalCount = len(opts.cves)
+        # Converting to a set removes duplicates
+        opts.cves = list(set(opts.cves))
+        dupesRemoved = originalCount - len(opts.cves)
+        if dupesRemoved:
+            logger.log(25, "{0} duplicate CVEs removed".format(dupesRemoved))
+        if opts.dryrun:
+            logger.log(25, "Skipping CVE retrieval due to --dryrun; would have retrieved: {0}".format(len(opts.cves)))
+            cveOutput = " ".join(opts.cves) + "\n"
+        else:
+            if iavaOutput:
+                print(file=sys.stderr)
+            cveOutput = apiclient.mget_cves(cves=opts.cves, numThreads=opts.threads, onlyCount=opts.count, outFormat=opts.outFormat, urls=opts.printUrls, fields=opts.fields, wrapWidth=opts.wrapWidth, product=opts.product)
     if opts.count:
         return
     if opts.pastebin:

--- a/rhsecapi.py
+++ b/rhsecapi.py
@@ -205,7 +205,7 @@ def parse_args():
         'RETRIEVE SPECIFIC IAVAS')
     g_listByIava.add_argument(
         '-i', '--iava', dest='iavas', metavar='YYYY-?-NNNN', action='append', 
-        help="Retrieve notice details for an IAVA number; specify option multiple times to retrieve multiple IAVAs at once (use below --extract-search option to lookup mapped CVEs)")
+        help="Retrieve notice details for an IAVA number; specify option multiple times to retrieve multiple IAVAs at once (use below --extract-cves option to lookup mapped CVEs)")
     # New group
     g_getCve = p.add_argument_group(
         'RETRIEVE SPECIFIC CVES')
@@ -213,7 +213,7 @@ def parse_args():
         'cves', metavar="CVE-YYYY-NNNN", nargs='*',
         help="Retrieve a CVE or list of CVEs (e.g.: 'CVE-2016-5387'); note that case-insensitive regex-matching is done -- extra characters & duplicate CVEs will be discarded")
     g_getCve.add_argument(
-        '-s', '--extract-search', action='store_true',
+        '-x', '--extract-cves', action='store_true',
         help="Extract CVEs from search query (as initiated by at least one of the --q-xxx options or the --iava option)")
     g_getCve.add_argument(
         '-0', '--stdin', action='store_true',
@@ -348,7 +348,7 @@ def main(opts):
     iavaOutput = ""
     cveOutput = ""
     if opts.doSearch:
-        if opts.extract_search:
+        if opts.extract_cves:
             result = apiclient.cve_search_query(params=opts.searchParams, outFormat='list')
             for cve in result:
                 opts.cves.append(cve)
@@ -363,7 +363,7 @@ def main(opts):
                 print(searchOutput, end="")
     if opts.iavas:
         logger.debug("IAVAs: {0}".format(opts.iavas))
-        if opts.extract_search:
+        if opts.extract_cves:
             result = apiclient.mget_iavas(iavas=opts.iavas, numThreads=opts.threads, onlyCount=opts.count, outFormat='list')
             opts.cves.extend(result)
         elif opts.count:

--- a/rhsecapi.py
+++ b/rhsecapi.py
@@ -358,7 +358,7 @@ def main(opts):
             if not opts.pastebin:
                 print(file=sys.stderr)
                 print(searchOutput, end="")
-    elif opts.iavas:
+    if opts.iavas:
         logger.debug("IAVAs: {0}".format(opts.iavas))
         if opts.extract_search:
             result = apiclient.mget_iavas(iavas=opts.iavas, numThreads=opts.threads, onlyCount=opts.count, outFormat='list')


### PR DESCRIPTION
Changelog:

- FIX: rhsda.extract_cves_from_input() no longer ignores case when removing duplicates #57
- FIX: duplicate CVEs that are present both in stdin and on cmdline are not removed #59 
- RFE: implement new IAVA support #51
- RFE: allow querying multiple IAVAs at once #12 
- RFE: implement RHSDA_URL environment variable #55
- RFE: Rename --extract-stdin to just --stdin #53
- RFE: display errata release_date field #52
- RFE: Rename --extract-search (-s) to --extract-cves (-x) #54 
- RFE: Show more CVE data when performing searches without --extract-cves #17
- RFE: make --q-xxx options mutually-exclusive with --iava & --stdin & CVE (args) #58 